### PR TITLE
Update site branding and add responsive Trainers page

### DIFF
--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -22,7 +22,7 @@ export function HeroSection() {
                   Transform Your Body, Elevate Your Mind
                 </h1>
                 <p className="text-balance text-lg text-gray-200 leading-relaxed drop-shadow-md">
-                  Welcome to Markville Fitness — where elite training meets personalized coaching. Join hundreds of members achieving their fitness goals with state-of-the-art equipment, expert trainers, and a community that pushes you to excel.
+                  Welcome to MFfitness — where elite training meets personalized coaching. Join hundreds of members achieving their fitness goals with state-of-the-art equipment, expert trainers, and a community that pushes you to excel.
                 </p>
               </div>
             </FadeIn>


### PR DESCRIPTION
- Updated site-wide branding from "Markville Fitness" to "MFfitness" for consistency across the logo and hero section.
- Added a new responsive Trainers page to showcase fitness staff across all device sizes.

[v0 Session](https://v0.app/chat/NS3Ctar7L9q)